### PR TITLE
fix POST data not working without string literals

### DIFF
--- a/curl.bqn
+++ b/curl.bqn
@@ -116,8 +116,8 @@ SetTimeoutms←{timeoutms 𝕊 session:
 # Use a POST method and set data to post
 SetData←{data 𝕊 session:
   "setting up POST request"Check EasySetoptLong⟨session.sessionPtr,curlOptions.post,1⟩
-  "setting POST data"Check EasySetoptStr⟨session.sessionPtr,curlOptions.postfields,data⟩
   "setting POST data size"Check EasySetoptLong⟨session.sessionPtr,curlOptions.postfieldsize,≠data⟩
+  "copying POST data"Check EasySetoptStr⟨session.sessionPtr,curlOptions.copypostfields,data⟩
   session
 }
 

--- a/ffi.bqn
+++ b/ffi.bqn
@@ -62,6 +62,7 @@ curlOptions←{
 
   # long integer options
   postfieldsize⇐60  # size of the POST input data
+  copypostfields⇐10165 # copy POST input data
   timeout⇐78  # timeout in seconds
   timeoutms⇐155  # timeout in milliseconds
 

--- a/ffi.bqn
+++ b/ffi.bqn
@@ -62,7 +62,6 @@ curlOptions←{
 
   # long integer options
   postfieldsize⇐60  # size of the POST input data
-  copypostfields⇐10165 # copy POST input data
   timeout⇐78  # timeout in seconds
   timeoutms⇐155  # timeout in milliseconds
 
@@ -75,6 +74,7 @@ curlOptions←{
   writedata⇐ptrOffset+1  # FILE* in which to write response content
   postfields⇐ptrOffset+15  # pointer to POST input data
   headerdata⇐ptrOffset+29  # FILE* in which to write response headers
+  copypostfields⇐ptrOffset+165 # copy POST input data
 
   # linked list options
   httpHeader⇐slistOffset+23  # HTTP headers as a list of strings

--- a/tests.bqn
+++ b/tests.bqn
@@ -36,7 +36,7 @@ simpleAPI_testsuite←⟨
   },
   "simple POST with headers"‿{𝕊𝕩:
     headers←⟨"Content-Type: application/json"⟩
-    r←headers Post ⟨httpbinURL∾"/post","{""key"": ""value""}"⟩
+    r←headers Post ⟨httpbinURL∾"/post",¯1000 + 1000 + "{""key"": 1}"⟩
     ! 200=r.code
     ! 0=r.redirectCount
     ! 1=⊑"HTTP/"⍷r.headers

--- a/tests.bqn
+++ b/tests.bqn
@@ -43,7 +43,7 @@ simpleAPI_testsuite←⟨
     ! 1=+´"Content-Type: "⍷r.headers
     ! 1=+´"Content-Length: "⍷r.headers
     ! 1=+´"""Content-Type"": ""application/json"""⍷r.content
-    ! 1=+´"""data"": ""{\""key\"": \""value\""}"""⍷r.content
+    ! 1=+´"""data"": ""{\""key\"": 1}"""⍷ r.content
   }
 ⟩
 


### PR DESCRIPTION
After asking on the [#bqn discord](https://discord.com/channels/821509511977762827/821511464090992640/1350811182767804479), @dzaima figured out the issue and pointed out that:

> Yep curl wanting the string to stay live until the session is closed, whereas bqn-curl/BQN FFI only makes it live until the specific curl_easy_setopt call ends?
> https://curl.se/libcurl/c/curl_easy_setopt.html
> > Strings passed to libcurl as `char *` arguments, are copied by the library; the string storage associated to the pointer argument may be discarded or reused after `curl_easy_setopt` returns. The only exception to this rule is really `CURLOPT_POSTFIELDS`

The initial repro case was this not working:
```bqn
Parse‿Export ← •Import "../bqn-libs/json.bqn"
curl         ← •Import "../bqn-curl/curl.bqn"

enc_foo ← •Show Export ⟨"foo"‿1⟩ #json exported
raw_foo ← •Show "[[""foo"",1]]"
Handle  ← {⊐⟜(⋈"form")⊸⊏˝ {Parse 𝕩.content} curl.Post 𝕩}
•Show Handle ("http://httpbin.org/post")‿enc_foo # bogus form data
•Show Handle ("http://httpbin.org/post")‿raw_foo # correct form data
```
, where the `raw_foo` case would work fine, but `enc_foo` would show bogus POST data.

Full credit to [Dzaima](https://discord.com/channels/821509511977762827/821511464090992640/1350843512354111528) came up with the solution.